### PR TITLE
Bugfix: Disabling trigger of DND on rightclick

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -458,6 +458,9 @@ var sipgateffx = {
 	},
 	
 	onMenuItemDoNotDisturb: function(e, action) {
+        if(e.button != 0) //only trigger on leftclick
+            return;
+
 		try {
 			if(action == 'disable') {
 				sipgateffx.component.setDoNotDisturb(false);


### PR DESCRIPTION
Opening contextmenu on the DND button triggered the DND button
